### PR TITLE
Fix: include_dirs

### DIFF
--- a/game.project
+++ b/game.project
@@ -29,5 +29,5 @@ package = com.defoldexample.videoplayer
 bundle_identifier = com.defoldexample.videoplayer
 
 [library]
-include_dirs = videoplayer
+include_dirs = mpeg
 


### PR DESCRIPTION
This PR corrects the `include_dirs` project value, allowing the Defold client to correctly fetch code from this repo.